### PR TITLE
Feature/exclude chromosomes in test

### DIFF
--- a/wisecondor.py
+++ b/wisecondor.py
@@ -480,12 +480,10 @@ def main():
 		type=str, default=None,
 		help='File containing cytoband information')
 		# Obtained here: http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz
-#	parser_plot.add_argument('-chromosomes',
-#		type=int, nargs='*', default=range(1,23),
-#		help='Integer of every chromosome to plot')
 	parser_plot.add_argument('-chromosomes', 
 		help="Integer of every chromosome to plot", 
-		type=lambda x: x.split(','))
+		type=(lambda x: map(int,x.split(','))),
+		default=range(1,23) )
 	parser_plot.add_argument('-columns',
 		type=int, default = 2,
 		help='Amount of columns to distribute plots over')

--- a/wisecondor.py
+++ b/wisecondor.py
@@ -453,9 +453,9 @@ def main():
 		type=float, default=None,
 		help='Minimum absolute z-score')
 	parser_test.add_argument('-chromosomes', 
-	help="Integer of every chromosome to plot", 
-	type=(lambda x: map(int,x.split(','))),
-	default=range(1,23) ),
+		help="Integer of every chromosome to plot, comma delimited",
+		type=(lambda x: map(int,x.split(','))),
+		default=range(1,23) ),
 	parser_test.add_argument('-mineffectsize',
 		type=float, default=0,
 		help='Minimum absolute relative change in read depth')
@@ -484,9 +484,9 @@ def main():
 		help='File containing cytoband information')
 		# Obtained here: http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz
 	parser_plot.add_argument('-chromosomes', 
-		help="Integer of every chromosome to plot", 
+		help="Integer of every chromosome to plot, comma delimited",
 		type=(lambda x: map(int,x.split(','))),
-		default=range(1,23) )
+		default=range(1,23))
 	parser_plot.add_argument('-columns',
 		type=int, default = 2,
 		help='Amount of columns to distribute plots over')

--- a/wisecondor.py
+++ b/wisecondor.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (C) 2016 VU University Medical Center Amsterdam
 # Author: Roy Straver (github.com/rstraver)
 #
@@ -479,9 +480,12 @@ def main():
 		type=str, default=None,
 		help='File containing cytoband information')
 		# Obtained here: http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz
-	parser_plot.add_argument('-chromosomes',
-		type=int, nargs='*', default=range(1,23),
-		help='Integer of every chromosome to plot')
+#	parser_plot.add_argument('-chromosomes',
+#		type=int, nargs='*', default=range(1,23),
+#		help='Integer of every chromosome to plot')
+	parser_plot.add_argument('-chromosomes', 
+		help="Integer of every chromosome to plot", 
+		type=lambda x: x.split(','))
 	parser_plot.add_argument('-columns',
 		type=int, default = 2,
 		help='Amount of columns to distribute plots over')

--- a/wisecondor.py
+++ b/wisecondor.py
@@ -230,13 +230,12 @@ def toolTest(args):
 	stouffCalls = []
 	chromWide = []
 
-	for i in range(22):
+	for i in [x-1 for x in args.chromosomes]:
 		start = sum(cleanedBins[:i])
 		end = sum(cleanedBins[:i + 1])
 		zTriangle = fillTriMin(cleanedZ[start:end],cleanedR[start:end],args.mineffectsize)
 		chromWide.append(zTriangle.getValue(0,end-start-1))
 		stoseg = zTriangle.segmentTri(z_threshold, 3)
-
 		for seg in stoseg:
 
 			perc = (seg[1][1] - seg[1][0]) / float(end - start) * 100
@@ -453,6 +452,10 @@ def main():
 	parser_test.add_argument('-minzscore',
 		type=float, default=None,
 		help='Minimum absolute z-score')
+	parser_test.add_argument('-chromosomes', 
+	help="Integer of every chromosome to plot", 
+	type=(lambda x: map(int,x.split(','))),
+	default=range(1,23) ),
 	parser_test.add_argument('-mineffectsize',
 		type=float, default=0,
 		help='Minimum absolute relative change in read depth')

--- a/wisetools.py
+++ b/wisetools.py
@@ -127,7 +127,7 @@ def convertBam(bamfile, binsize=1000000, minShift=4, threshold=4, mapq=1, demand
 		if stairSize <= threshold or threshold < 0:
 			for read in readBuff:
 				location = read.pos / binsize
-				counts[location] += 1
+				counts[int(location)] += 1
 				#if location >= len(counts):
 				#	print read
 

--- a/wisetools.py
+++ b/wisetools.py
@@ -232,7 +232,7 @@ def scaleSample(sample, fromSize, toSize):
 		newLen = int(np.ceil(len(chromData)/float(scale)))
 		scaledChrom = np.zeros(newLen, dtype=np.int32)
 		for i in range(newLen):
-			scaledChrom[i] = np_sum(chromData[i*scale:i*scale+scale])
+			scaledChrom[i] = np_sum(chromData[int(i*scale):int(i*scale+scale)])
 			returnSample[chrom] = scaledChrom
 	return returnSample
 


### PR DESCRIPTION
Hey all,

Our (mumc) adjustments are the following:
- Included the chromosome filter option already in the test tool, such that we never even generate the data for the chromosomes iso leaving them out of the report and the plots
- Formatted/parsed the chromosome argument slightly more pythonic: "13,18,21" ipv "13 18 21"
(more convenient in our scripts)
Feel free to merge/adjust/neglect them if you like (however it would be nice if we can stick to the master branch also for our internal releases :-))

Cheers,
Bart